### PR TITLE
Bug fix: Keyerror on 'output_manager'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ temp/
 storage/
 output_test/
 NOTES-TEMP FILES/
+.idea

--- a/config/Estimator.py
+++ b/config/Estimator.py
@@ -115,7 +115,8 @@ class Estimator(object):
 	def __getstate__(self):
 		state = self.__dict__.copy()
 		# Don't pickle baz
-		del state["output_manager"]
+		if "output_manager" in state:  # if not present, cause a crash on startup because of recursive call on the same dict
+			del state["output_manager"]
 		return state
 
 '''


### PR DESCRIPTION
Created conda environnement using the given yml file, though I had always the same error:
Keyerror: 'output_manager' in config/Estimator.py
![grafik](https://user-images.githubusercontent.com/24982486/143476828-4f343d6d-090b-4c5a-9613-c5a02e7337cf.png)
